### PR TITLE
feat(project): create typings

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,61 @@
+declare module 'bpmn-js-cli' {
+  export { Cli, Initializer } from 'bpmn-js-cli/lib';
+}
+
+declare module 'bpmn-js-cli/lib' {
+  import { Connection, Shape } from 'bpmn-js';
+  import { Injector } from 'didi';
+
+  export interface Point {
+    x: number;
+    y: number;
+  }
+
+  /**
+   * The default CLI initializer that sets up available parsers and commands.
+   *
+   * @param cli The Cli object to initialize
+   */
+  export function Initializer(cli: Cli): void;
+
+  export class Cli {
+    constructor(config: any, injector: Injector);
+
+    append(source: string | Shape, type: string, delta: string | Point): string;
+
+    connect(
+      sourceId: string | Shape,
+      target: string | Shape,
+      type: string,
+      parent?: string | Shape
+    ): string;
+
+    create(
+      type: string,
+      position: Point,
+      parent: string | Shape,
+      isAttach?: boolean
+    ): string;
+
+    elements(): string[];
+
+    move(
+      shapes: (string | Shape)[],
+      delta: Point,
+      newParent?: string | Shape,
+      isAttach?: boolean
+    ): Shape[];
+
+    removeConnection(element: string | Connection): Connection;
+
+    removeShape(shape: string | Shape): Shape;
+
+    setLabel(element: string | Shape, label: string): void;
+
+    undo(): void;
+
+    redo(): void;
+
+    save(format: 'svg' | 'bpmn'): void;
+  }
+}


### PR DESCRIPTION
This is a first attempt at typings for the CLI.

Unfortuntely `bpmn-js` and `didi` typings are required too.
```ts
import { Connection, Shape } from 'bpmn-js';
import { Injector } from 'didi';
```

And I have those [here](https://github.com/lppedd/bpmnio-typings/tree/master/src/%40types).  
How do we procede from here?