### PR TITLE
fix: Regex for splitting args

### DIFF
--- a/lib/Cli.js
+++ b/lib/Cli.js
@@ -204,9 +204,11 @@ Cli.prototype.exec = function() {
 
   // convert mixed whitespace separated string / object assignments in args list
   // to correct argument representation
+  // example: 'Activity_16tvcc9 bpmn:ServiceTask 150, -50' 
+  //          => [ 'Activity_16tvcc9', 'bpmn:ServiceTask', '150, -50' ] 
   asArray(arguments).forEach(function(arg) {
     if (isString(arg)) {
-      args = args.concat(arg.split(/\s+/));
+      args = args.concat(arg.match(/(\S+,\s*\S+|\S+)/g));
     } else {
       args.push(arg);
     }


### PR DESCRIPTION
Trying your demo.js throws the error `Uncaught Error: failed to execute <append> with args <[Activity_16tvcc9, bpmn:EndEvent, 150,, -50]> : Cli.prototype.parseArguments/<@http://localhost:8001/node_modules/.vite/deps/bpmn-js-cli.js?v=5dca5f58:514:13`

Inspecting the code I realized, that your demo code block

```js
var endEvent = cli.append(
  serviceTask,
  'bpmn:EndEvent',
  '150, 0'
);
```

includes a whitespace before the y-point. Your CLI arguments split case doesn't handle that, so I come up with a fix to solve this case and hoping not to break other stuff :D